### PR TITLE
Fix light not updating immediately after movement.

### DIFF
--- a/range/scripts/vscripts/fl_test.lua
+++ b/range/scripts/vscripts/fl_test.lua
@@ -504,7 +504,7 @@ local PICKUP_TRIGGER_DELAY = 0.2
 	 	}
 	 	m_hLight = SpawnEntityFromTableSynchronous( "light_spot", lightTable )
 	 	m_hLight:SetAngles( angAttachment[1], angAttachment[2], angAttachment[3] );
-	 	m_hLight:SetParent(thisEntity, "flashlight_beam")
+	 	m_hLight:SetParent(m_hHandAttachment, "flashlight_beam")
  	end
  end
  


### PR DESCRIPTION
To reproduce the bug, turn on the flashlight and then teleport. The light beam will be slightly off until you move your head or hand to snap it into the right position.

This desynchronization is described here: https://developer.valvesoftware.com/wiki/SteamVR/Environments/Scripting/Custom_Tool_Creation#Parenting_other_models_to_the_tool